### PR TITLE
fetch_sources.py: Various cleanups

### DIFF
--- a/fetch_sources.py
+++ b/fetch_sources.py
@@ -1,45 +1,76 @@
-#!/usr/bin/python
+#!/usr/bin/python2
+# encoding=utf-8
+# Copyright © 2017 Intel Corporation
 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Attempt to fetch build_support repository, then fetch additional
+repositories.
+"""
+
+from __future__ import print_function
 import argparse
 import os
 import sys
+
 import git
-build_support_dir = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(sys.argv[0])), "repos", "mesa_ci"))
+
+build_support_dir = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "repos", "mesa_ci"))
+
+def try_clone(repo):
+    print('Trying to clone build support from {}'.format(repo))
+    git.Repo.clone_from(repo, build_support_dir)
+
+
 if not os.path.exists(build_support_dir):
-    repo_dir = os.path.split(build_support_dir)[0]
+    repo_dir = os.path.dirname(build_support_dir)
     if not os.path.exists(repo_dir):
         os.makedirs(repo_dir)
-    success = False
+
     try:
-        git.Repo.clone_from("git://otc-mesa-android.local/git/mesa_ci/origin", build_support_dir)
-        success = True
-    except:
-        success = False
-    if not success:
+        try_clone("git://otc-mesa-android.local/git/mesa_ci/origin")
+    except git.exc.GitCommandError:
         try:
-            git.Repo.clone_from("git://otc-mesa-android.jf.intel.com/git/mesa_ci/origin", build_support_dir)
-            success = True
-        except:
-            success = False
-    if not success:
-        try:
-            git.Repo.clone_from("git://github.com/janesma/mesa_ci.git", build_support_dir)
-            success = True
-        except:
-            print "ERROR: could not clone sources"
-            
-sys.path.append(build_support_dir)
+            try_clone("git://otc-mesa-android.jf.intel.com/git/mesa_ci/origin")
+        except git.exc.GitCommandError:
+            try:
+                try_clone("git://github.com/janesma/mesa_ci.git")
+            except git.exc.GitCommandError:
+                print("ERROR: could not clone sources")
+                sys.exit(1)
+
+sys.path.insert(0, build_support_dir)
 import build_support as bs
 
-parser = argparse.ArgumentParser(description="checks out branches and commits")
-parser.add_argument('--branch', type=str, default="mesa_master",
-                    help="The branch to base the checkout on. (default: %(default)s)")
-parser.add_argument('commits', metavar='commits', type=str, nargs='*',
-                    help='commits to check out, in repo=sha format')
-args = parser.parse_args()
 
-repos = bs.RepoSet(clone=True)
-repos.fetch()
-bs.BuildSpecification().checkout(args.branch, args.commits)
+def main():
+    parser = argparse.ArgumentParser(description="checks out branches and commits")
+    parser.add_argument('--branch', type=str, default="mesa_master",
+                        help="The branch to base the checkout on. (default: %(default)s)")
+    parser.add_argument('commits', metavar='commits', type=str, nargs='*',
+                        help='commits to check out, in repo=sha format')
+    args = parser.parse_args()
+
+    repos = bs.RepoSet(clone=True)
+    repos.fetch()
+    bs.BuildSpecification().checkout(args.branch, args.commits)
 
 
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
A not-so complete list:
- add copyright
- add docstring
- use print function instead of print statement
- Don't set flags in try/except, just use the except blocks for what
  they're for
- exit with error code of no build-support repo can be cloned
- put build_support at front of path to speed up imports
- Use a main function
- Print a message for each repo tried
- catch a single exception rather than use a bare except

The diff for this is pretty impossible to read. I can split it up into more manageable chunks if you prefer.