### PR TITLE
fetch_sources: implement retrying of fetch/checkout

### DIFF
--- a/fetch_sources.py
+++ b/fetch_sources.py
@@ -28,6 +28,7 @@ from __future__ import print_function
 import argparse
 import os
 import sys
+import time
 
 import git
 
@@ -69,8 +70,18 @@ def main():
 
     repos = bs.RepoSet()
     repos.clone()
-    repos.fetch()
-    bs.BuildSpecification().checkout(args.branch, args.commits)
+    for i in range(5):
+        repos.fetch()
+        try:
+            print("Checking out specified commit (try {}/5)".format(i+1))
+            bs.BuildSpecification().checkout(args.branch, args.commits)
+        except git.GitCommandError:
+            print("Unable to checkout specified commit, retrying in 5s..")
+            time.sleep(5)
+        else:
+            return
+    raise Exception("ERROR: Unable to checkout specified commit.")
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Sometimes checkouts of a specific commit fail if the repo has not
been synced to the git cache yet. This retries the fetch and
checkout a few times until it either succeeds or gives up.